### PR TITLE
Add: 推箱子分享功能（导入/直接试玩双链接 + 直玩添加本地关卡）

### DIFF
--- a/sokoban/css/levels.css
+++ b/sokoban/css/levels.css
@@ -606,3 +606,107 @@ body {
     .action-row #upload-btn { padding: 10px 12px; }
     .import-row #import-btn { padding: 10px 12px; }
 }
+
+/* ===== 分享弹层（两种链接：直接试玩 / 导入编辑）===== */
+.share-pop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    display: none;
+    align-items: center;
+    justify-content: center;
+    z-index: 1800;
+    padding: 16px;
+}
+
+.share-pop.open {
+    display: flex;
+}
+
+.share-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    width: 100%;
+    max-width: 460px;
+    padding: 18px;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.25);
+    color: var(--text-main);
+}
+
+.share-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 17px;
+    font-weight: bold;
+    margin-bottom: 8px;
+}
+
+.share-close {
+    background: transparent;
+    border: none;
+    color: var(--text-main);
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.7;
+    padding: 0 4px;
+}
+
+.share-close:hover {
+    opacity: 1;
+}
+
+.share-tip {
+    font-size: 13px;
+    opacity: 0.8;
+    margin-bottom: 14px;
+    line-height: 1.5;
+}
+
+.share-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.share-row:last-child {
+    margin-bottom: 0;
+}
+
+.share-label {
+    flex: 0 0 80px;
+    font-size: 13px;
+    font-weight: bold;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.share-input {
+    flex: 1;
+    min-width: 0;
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid var(--card-border);
+    background: var(--bg-main);
+    color: var(--text-main);
+    font-size: 12px;
+    font-family: monospace;
+}
+
+.share-input:focus {
+    border-color: var(--btn-bg);
+    outline: none;
+}
+
+.share-copy {
+    flex-shrink: 0;
+}
+
+@media (max-width: 480px) {
+    .share-label { flex-basis: 68px; font-size: 12px; }
+    .share-input { font-size: 11px; padding: 7px 8px; }
+}

--- a/sokoban/game.html
+++ b/sokoban/game.html
@@ -45,6 +45,7 @@
             <button id="reset-btn" class="button">重置</button>
             <button id="next-level-btn" class="button">下一关</button>
             <button id="upload-btn" class="button">上传关卡</button>
+            <button id="save-shared-btn" class="button">添加</button>
             <input type="file" id="level-file" accept=".json,.txt,application/json,text/plain" style="display:none">
         </div>
 

--- a/sokoban/js/game.js
+++ b/sokoban/js/game.js
@@ -17,6 +17,7 @@ class SokobanGame {
         this.levels = (Array.isArray(levels) && levels.length) ? levels
             : (typeof SOKOBAN_LEVELS !== 'undefined' ? SOKOBAN_LEVELS : []);
         this.source = 'default';   // 'default'（内置）| 'custom'（上传试玩）
+        this.fromShare = false;    // 是否来自「分享直玩」(?play=)，决定显示“添加到自定义关卡”
         this.levelIndex = 0;
         this.grid = [];      // 静态层：'wall' | 'floor' | 'target'
         this.rows = 0;
@@ -139,9 +140,12 @@ class SokobanGame {
         const prevBtn = document.getElementById('prev-level-btn');
         const nextBtn = document.getElementById('next-level-btn');
         const uploadBtn = document.getElementById('upload-btn');
+        const saveSharedBtn = document.getElementById('save-shared-btn');
         if (prevBtn) prevBtn.style.display = multi ? '' : 'none';
         if (nextBtn) nextBtn.style.display = multi ? '' : 'none';
         if (uploadBtn) uploadBtn.style.display = (this.source === 'custom') ? 'none' : '';
+        // “添加到自定义关卡”仅分享直玩(?play=)时显示
+        if (saveSharedBtn) saveSharedBtn.style.display = this.fromShare ? '' : 'none';
     }
 
     // ─── 移动与推箱 ─────────────────────────────────────────────
@@ -310,6 +314,9 @@ class SokobanGame {
 
         // 上传自定义关卡
         this._bindUpload();
+
+        // 分享直玩时「添加到自定义关卡」
+        document.getElementById('save-shared-btn')?.addEventListener('click', () => this._saveSharedToUserLevels());
     }
 
     // ─── 自定义关卡（上传试玩）─────────────────────────────
@@ -360,6 +367,28 @@ class SokobanGame {
         });
     }
 
+    /** 把当前「分享直玩」关卡存入本地自定义关卡库（去重） */
+    _saveSharedToUserLevels() {
+        if (!this.fromShare) return;
+        const lv = this.levels[this.levelIndex];
+        if (!lv) return;
+        try {
+            const existing = (typeof SokobanUserLevels !== 'undefined' && SokobanUserLevels.getUserLevels)
+                ? SokobanUserLevels.getUserLevels() : [];
+            const dup = existing.some(function (it) {
+                return it.name === lv.name && JSON.stringify(it.map) === JSON.stringify(lv.map);
+            });
+            if (dup) {
+                this._toast('《' + lv.name + '》已在自定义关卡中');
+                return;
+            }
+            SokobanUserLevels.saveUserLevel({ name: lv.name, map: lv.map });
+            this._toast('已添加到自定义关卡《' + lv.name + '》');
+        } catch (e) {
+            this._toast('添加失败：' + (e && e.message ? e.message : e));
+        }
+    }
+
     /** 轻量提示（解析/加载结果） */
     _toast(msg) {
         const el = document.getElementById('level-toast');
@@ -403,6 +432,25 @@ window.addEventListener('DOMContentLoaded', function () {
             new SokobanGame(levels, startIndex < levels.length ? startIndex : 0);
         });
         return;
+    }
+
+    // 分享链接「直接打开试玩」：?play=<code> 携带编码后的单关，打开即玩。
+    // 不自保存到本地关卡（与 ?level=N 官方试玩、localStorage 试玩区分），不污染我的关卡库。
+    var playCode = params.get('play');
+    if (playCode) {
+        var shared = null;
+        try {
+            shared = (typeof SokobanUserLevels !== 'undefined' && SokobanUserLevels.decodeLevel)
+                ? SokobanUserLevels.decodeLevel(playCode) : null;
+        } catch (e) { shared = null; }
+        if (shared && Array.isArray(shared.map) && shared.map.length) {
+            var sharedName = shared.name || '分享关卡';
+            var g0 = new SokobanGame([]);
+            g0.fromShare = true;   // 来自分享直玩，显示“添加到自定义关卡”
+            g0.loadCustomLevels([{ name: sharedName, map: shared.map }], sharedName);
+            return;
+        }
+        // 解码失败（分享码损坏）：继续走下方默认加载，避免白屏
     }
 
     var playTarget = null;

--- a/sokoban/js/viewer.js
+++ b/sokoban/js/viewer.js
@@ -147,11 +147,71 @@
         document.body.removeChild(ta);
     }
 
+    // ── 分享弹层：提供两种链接 ──
+    // 1) 直接试玩：game.html?play=<code> —— 对方打开即开玩，不写入本地关卡
+    // 2) 导入编辑：editor.html?import=<code> —— 对方打开即载入编辑器，可保存 / 试玩
+    var sharePop = null;
+    var sharePopInit = false;
+    function ensureSharePop() {
+        if (sharePop) return sharePop;
+        var pop = document.createElement('div');
+        pop.className = 'share-pop';
+        pop.innerHTML =
+            '<div class="share-card">' +
+                '<div class="share-head"><span>分享关卡</span>' +
+                    '<button class="share-close" aria-label="关闭">&times;</button></div>' +
+                '<p class="share-tip">两种分享链接任选：对方打开即可直接试玩，或导入到他自己的关卡库。</p>' +
+                '<div class="share-row">' +
+                    '<span class="share-label"><i class="fas fa-play"></i>直接试玩</span>' +
+                    '<input class="share-input" type="text" readonly>' +
+                    '<button class="button small share-copy" data-kind="play">复制</button>' +
+                '</div>' +
+                '<div class="share-row">' +
+                    '<span class="share-label"><i class="fas fa-file-import"></i>导入编辑</span>' +
+                    '<input class="share-input" type="text" readonly>' +
+                    '<button class="button small share-copy" data-kind="import">复制</button>' +
+                '</div>' +
+            '</div>';
+        document.body.appendChild(pop);
+        pop.addEventListener('click', function (e) {
+            if (e.target === pop || (e.target.closest && e.target.closest('.share-close'))) closeSharePop();
+        });
+        sharePop = pop;
+        return pop;
+    }
+    function closeSharePop() { if (sharePop) sharePop.classList.remove('open'); }
+
     function shareLevel(level) {
         var code = SokobanUserLevels.encodeLevel(level);
         var base = location.origin + location.pathname.substring(0, location.pathname.lastIndexOf('/') + 1);
-        var url = base + 'editor.html?import=' + encodeURIComponent(code);
-        copyText(url, '分享链接已复制，去粘贴给好友吧');
+        var playUrl = base + 'game.html?play=' + encodeURIComponent(code);
+        var importUrl = base + 'editor.html?import=' + encodeURIComponent(code);
+
+        var pop = ensureSharePop();
+        var inputs = pop.querySelectorAll('.share-input');
+        inputs[0].value = playUrl;     // 直接试玩
+        inputs[1].value = importUrl;   // 导入编辑
+
+        // 复制按钮：每次分享重新绑定（onclick 覆盖，避免重复监听）
+        pop.querySelectorAll('.share-copy').forEach(function (btn) {
+            btn.onclick = function () {
+                var url = btn.previousElementSibling.value;
+                var kind = btn.getAttribute('data-kind');
+                copyText(url, '已复制「' + (kind === 'play' ? '直接试玩' : '导入编辑') + '」链接');
+            };
+        });
+
+        pop.classList.add('open');
+        // 自动选中首行链接，方便手动复制
+        if (inputs[0]) { inputs[0].focus(); inputs[0].select(); }
+    }
+
+    // 全局 Esc 关闭分享弹层（仅注册一次）
+    if (!sharePopInit) {
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape' && sharePop && sharePop.classList.contains('open')) closeSharePop();
+        });
+        sharePopInit = true;
     }
 
     // 编辑：携带关卡编码与 id 跳转制作页，编辑后保存即覆盖原关卡


### PR DESCRIPTION
- viewer.js 分享按钮改为弹层，提供「直接试玩」(game.html?play=) 与「导入编辑」(editor.html?import=) 两种链接
- game.js 新增 ?play= 直开试玩分支，并支持「添加」按钮将分享关卡存入本地自定义关卡（去重）
- game.html 控制栏新增「添加」按钮（仅分享直玩时显示）
- levels.css 新增分享弹层样式，复用现有变量明暗自适应

## PR Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x] to select (将 [ ] 换成 [x] 来选择) -->

**Please read and check followings before submitting a PR.**

- [x] The changes have been tested (for bug fixes / features).
- [x] Others (Update, Documentation, Translation, etc...)

## PR Type
<!-- What kind of change does this PR introduce? -->

- [ ] Bugfix.
- [x] Feature.
- [x] Improvement.
- [ ] Code style update (e.g. formatting).
- [ ] Refactoring (no changes to functionality and APIs).
- [ ] Documentation.
- [ ] Translation.
- [ ] Other... Please describe:
